### PR TITLE
Improve security for the api call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   - pip install WebTest
   # Waiting awnser next release AnyBlok >= 0.22.6
   - pip install -e git+https://github.com/Anyblok/AnyBlok@master#egg=AnyBlok
+  # Waiting restric query by user AnyBlok_Pyramid >= 1.1.2
+  - pip install -e git+https://github.com/Anyblok/AnyBlok_pyramid@master#egg=anyblok_pyramid
   - pip install -e .
 
 env:

--- a/anyblok_furetui/__init__.py
+++ b/anyblok_furetui/__init__.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # This file is a part of the AnyBlok project
 #
-#    Copyright (C) 2017 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2018 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2020 Jean-Sebastien SUZANNE <js.suzanne@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
+
+from .security import furet_ui_call  # noqa

--- a/anyblok_furetui/__init__.py
+++ b/anyblok_furetui/__init__.py
@@ -8,4 +8,4 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-from .security import furet_ui_call  # noqa
+from .security import exposed_method  # noqa

--- a/anyblok_furetui/furetui/__init__.py
+++ b/anyblok_furetui/furetui/__init__.py
@@ -20,6 +20,7 @@ logger = getLogger(__name__)
 
 def import_module(reload=None):
     from . import core
+    from . import system
     from . import furetui
     from . import space
     from . import resource
@@ -27,6 +28,7 @@ def import_module(reload=None):
     from . import crud
     if reload is not None:
         reload(core)
+        reload(system)
         reload(furetui)
         reload(space)
         reload(resource)

--- a/anyblok_furetui/furetui/furetui.py
+++ b/anyblok_furetui/furetui/furetui.py
@@ -7,7 +7,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 from anyblok.declarations import Declarations
-from pyramid.httpexceptions import HTTPUnauthorized
+from pyramid.httpexceptions import HTTPForbidden
 from anyblok_pyramid_rest_api.crud_resource import saved_errors_in_request
 from .template import Template
 from anyblok.blok import BlokManager
@@ -157,7 +157,7 @@ class FuretUI:
     def call_exposed_method(cls, request, resource=None, model=None, call=None,
                             data=None, pks=None):
         if call not in cls.registry.exposed_methods.get(model, {}):
-            raise HTTPUnauthorized(f"the method '{call}' is not exposed")
+            raise HTTPForbidden(f"the method '{call}' is not exposed")
 
         def apply_value(value):
             return value() if callable(value) else value

--- a/anyblok_furetui/furetui/furetui.py
+++ b/anyblok_furetui/furetui/furetui.py
@@ -133,3 +133,9 @@ class FuretUI:
     @classmethod
     def check_security(cls, request):
         return True
+
+    @classmethod
+    def call_by_api(cls, request, resource=None, model=None, call=None,
+                    data=None, pks=None):
+        res = None
+        return res

--- a/anyblok_furetui/furetui/furetui.py
+++ b/anyblok_furetui/furetui/furetui.py
@@ -7,6 +7,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 from anyblok.declarations import Declarations
+from pyramid.httpexceptions import HTTPUnauthorized
 from .template import Template
 from anyblok.blok import BlokManager
 from anyblok.config import Configuration
@@ -135,7 +136,10 @@ class FuretUI:
         return True
 
     @classmethod
-    def call_by_api(cls, request, resource=None, model=None, call=None,
-                    data=None, pks=None):
+    def call_exposed_method(cls, request, resource=None, model=None, call=None,
+                            data=None, pks=None):
+        if call not in cls.registry.exposed_methods.get(model, {}):
+            raise HTTPUnauthorized(f'the method {call} is not exposed')
+
         res = None
         return res

--- a/anyblok_furetui/furetui/furetui.py
+++ b/anyblok_furetui/furetui/furetui.py
@@ -137,19 +137,47 @@ class FuretUI:
         return True
 
     @classmethod
+    def get_exposed_method_options(cls, request, resource, model, call, data,
+                                   pks):
+
+        def get_resource():
+            if resource == '0':
+                return None
+
+            return cls.registry.FuretUI.Resource.query().get(int(resource))
+
+        res = [
+            ('request', request),
+            ('authenticated_userid', request.authenticated_userid),
+            ('resource', get_resource),
+        ]
+        return res
+
+    @classmethod
     def call_exposed_method(cls, request, resource=None, model=None, call=None,
                             data=None, pks=None):
         if call not in cls.registry.exposed_methods.get(model, {}):
             raise HTTPUnauthorized(f"the method '{call}' is not exposed")
 
+        def apply_value(value):
+            return value() if callable(value) else value
+
+        options = {}
         definition = cls.registry.exposed_methods[model][call]
-        args = []
         obj = cls.registry.get(model)
         if definition['is_classmethod'] is False:
             obj = obj.from_primary_keys(**pks)
 
+        for (key, value) in cls.get_exposed_method_options(
+            request, resource, model, call, data, pks
+        ):
+            if definition[key] is True:
+                options[key] = apply_value(value)
+            elif definition[key]:
+                options[definition[key]] = apply_value(value)
+
         res = None
         with saved_errors_in_request(request):
-            res = getattr(obj, call)(*args, **data)
+            res = getattr(obj, call)(**options, **data)
 
         return res

--- a/anyblok_furetui/furetui/furetui.py
+++ b/anyblok_furetui/furetui/furetui.py
@@ -171,7 +171,8 @@ class FuretUI:
                 request.authenticated_userid, model, permission
             ):
                 raise HTTPForbidden(
-                    f"'{userId}' is not allowed to access '{model}'")
+                    f"The user '{userId}' has not he permission '{permission}'"
+                    f" to access the model '{model}'")
 
         obj = cls.registry.get(model)
         if definition['is_classmethod'] is False:

--- a/anyblok_furetui/furetui/menus.py
+++ b/anyblok_furetui/furetui/menus.py
@@ -200,3 +200,21 @@ class Call(
         foreign_key=Declarations.Model.System.Model.use(
             'name').options(ondelete='cascade'))
     method = String(nullable=False, size=256)
+
+    @classmethod
+    def before_insert_orm_event(cls, mapper, connection, target):
+        target.is_an_exposed_method()
+
+    @classmethod
+    def before_update_orm_event(cls, mapper, connection, target):
+        target.is_an_exposed_method()
+
+    def is_an_exposed_method(self):
+        """When creating or updating a User.Authorization, check that all rules
+        objects exists or return an AuthorizationValidationException
+
+        :exception: AuthorizationValidationException
+        """
+        if self.method not in self.registry.exposed_methods.get(self.model, {}):
+            raise Exception(
+                f"'{self.model}=>{self.method}' is not an exposed method")

--- a/anyblok_furetui/furetui/system.py
+++ b/anyblok_furetui/furetui/system.py
@@ -25,5 +25,5 @@ class Blok:
 
     @exposed_method(is_classmethod=False, permission='admin')
     def upgrade(self):
-        super(Blok, self).uninstall()
+        super(Blok, self).upgrade()
         # MAIBE reload UI

--- a/anyblok_furetui/furetui/system.py
+++ b/anyblok_furetui/furetui/system.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok project
+#
+#    Copyright (C) 2020 Jean-Sebastien SUZANNE <js.suzanne@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok import Declarations
+from ..security import exposed_method
+
+
+@Declarations.register(Declarations.Model.System)
+class Blok:
+
+    @exposed_method(is_classmethod=False, permission='admin')
+    def install(self):
+        super(Blok, self).install()
+        # MAIBE reload UI
+
+    @exposed_method(is_classmethod=False, permission='admin')
+    def uninstall(self):
+        super(Blok, self).uninstall()
+        # MAIBE reload UI
+
+    @exposed_method(is_classmethod=False, permission='admin')
+    def upgrade(self):
+        super(Blok, self).uninstall()
+        # MAIBE reload UI

--- a/anyblok_furetui/furetui/tests/test_menus.py
+++ b/anyblok_furetui/furetui/tests/test_menus.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok project
+#
+#    Copyright (C) 2020 Jean-Sebastien SUZANNE <js.suzanne@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
 import pytest
 from furl import furl
 
@@ -22,7 +30,7 @@ class Mixin:
             Menu.Resource.insert(label="Resource 1", resource=resource),
             Menu.Url.insert(label="Resource 2", url="http://anyblok.org"),
             Menu.Call.insert(label="Resource 3", model="Model.System.Blok",
-                             method="test_method"),
+                             method="install"),
         ])
         node2 = Menu.Node.insert(label="Node 2")
         node2.children.extend([
@@ -38,7 +46,7 @@ class Mixin:
             Menu.Resource.insert(label="Resource 7", resource=resource),
             Menu.Url.insert(label="Resource 8", url="http://anyblok.org"),
             Menu.Call.insert(label="Resource 9", model="Model.System.Blok",
-                             method="test_method"),
+                             method="install"),
         ])
         return space if with_space else resource
 
@@ -101,7 +109,7 @@ class Mixin:
                         'icon_type': None,
                         'id': call_id('Resource 9'),
                         'label': 'Resource 9',
-                        'method': 'test_method',
+                        'method': 'install',
                         'model': 'Model.System.Blok',
                         'order': 100,
                         'resource': resource.id if with_resource else None,
@@ -149,7 +157,7 @@ class Mixin:
                                 'icon_type': None,
                                 'id': call_id('Resource 3'),
                                 'label': 'Resource 3',
-                                'method': 'test_method',
+                                'method': 'install',
                                 'model': 'Model.System.Blok',
                                 'order': 100,
                                 'resource': (

--- a/anyblok_furetui/furetui/views/call.py
+++ b/anyblok_furetui/furetui/views/call.py
@@ -18,18 +18,10 @@ def call_classmethod(request):
     registry = request.anyblok.registry
     params = request.matchdict
     body = request.json_body
-    pks = body.get('pks', {})
-    data = body.get('data', {})
-    data['authenticated_userid'] = request.authenticated_userid
     # TODO call security hooks
 
     with saved_errors_in_request(request):
-        Model = registry.get(params['model'])
-        obj = Model
-        if pks:
-            obj = Model.from_primary_keys(**pks)
-
-        res = getattr(obj, params['call'])(**data)
+        res = registry.FuretUI.call_by_api(request, **params, **body)
         if res is None:
             return []
 

--- a/anyblok_furetui/furetui/views/call.py
+++ b/anyblok_furetui/furetui/views/call.py
@@ -1,5 +1,4 @@
 from anyblok_pyramid import current_blok
-from anyblok_pyramid_rest_api.crud_resource import saved_errors_in_request
 from cornice import Service
 from anyblok_furetui.security import authorized_user
 
@@ -20,9 +19,8 @@ def call_classmethod(request):
     body = request.json_body
     # TODO call security hooks
 
-    with saved_errors_in_request(request):
-        res = registry.FuretUI.call_by_api(request, **params, **body)
-        if res is None:
-            return []
+    res = registry.FuretUI.call_exposed_method(request, **params, **body)
+    if res is None:
+        return []
 
-        return res
+    return res

--- a/anyblok_furetui/plugins.py
+++ b/anyblok_furetui/plugins.py
@@ -1,0 +1,36 @@
+# This file is a part of the AnyBlok / Pyramid project
+#
+#    Copyright (C) 2020 Jean-Sebastien SUZANNE <js.suzanne@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok.model.plugins import ModelPluginBase
+
+
+class ExposedMethod(ModelPluginBase):
+    """An AnyBlok plugin that helps to add exposed methods by models
+    """
+
+    def __init__(self, registry):
+        if not hasattr(registry, "exposed_methods"):
+            registry.exposed_methods = {}
+
+        super().__init__(registry)
+
+    def transform_base_attribute(
+        self, attr, method, namespace, base, transformation_properties,
+        new_type_properties,
+    ):
+        """Find exposed methods in the base to save the
+        namespace and the method in the registry
+        :param attr: attribute name
+        :param method: method pointer of the attribute
+        :param namespace: the namespace of the model
+        :param base: One of the base of the model
+        :param transformation_properties: the properties of the model
+        :param new_type_properties: param to add in a new base if need
+        """
+        if getattr(method, "is_an_exposed_method", False) is True:
+            model = self.registry.exposed_methods.setdefault(namespace, {})
+            model.update({method.__name__: method.exposure_description})

--- a/anyblok_furetui/security.py
+++ b/anyblok_furetui/security.py
@@ -1,6 +1,7 @@
 # This file is a part of the AnyBlok / Pyramid project
 #
 #    Copyright (C) 2018 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2020 Jean-Sebastien SUZANNE <js.suzanne@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
@@ -24,3 +25,11 @@ def authorized_user(request, *a, **kw):
         if not registry.FuretUI.check_security(request):
             request.errors.add('body', 'userid', 'The user is not allow')
             request.errors.status = 405
+
+
+def furet_ui_call(is_classmethod=True, request=None, authenticated_userid=None):
+
+    def wrapper(func):
+        return func
+
+    return wrapper

--- a/anyblok_furetui/security.py
+++ b/anyblok_furetui/security.py
@@ -63,8 +63,8 @@ def exposed_method(**kwargs):
                        (default None)
     """
     exposed_kwargs = dict(
-        is_classmethod=True, request=None, authenticated_userid=None,
-        resource=None)
+        is_classmethod=True, permission=None, request=None,
+        authenticated_userid=None, resource=None)
     exposed_kwargs.update(kwargs)
     autodoc = "**exposed_method** defined with the arguments {exposed_kwargs:r}"
 

--- a/anyblok_furetui/security.py
+++ b/anyblok_furetui/security.py
@@ -27,8 +27,8 @@ def authorized_user(request, *a, **kw):
             request.errors.status = 405
 
 
-def furet_ui_call(is_classmethod=True, request=None, authenticated_userid=None,
-                  resource=None):
+def exposed_method(is_classmethod=True, request=None, authenticated_userid=None,
+                   resource=None):
 
     def wrapper(func):
         return func

--- a/anyblok_furetui/security.py
+++ b/anyblok_furetui/security.py
@@ -27,7 +27,8 @@ def authorized_user(request, *a, **kw):
             request.errors.status = 405
 
 
-def furet_ui_call(is_classmethod=True, request=None, authenticated_userid=None):
+def furet_ui_call(is_classmethod=True, request=None, authenticated_userid=None,
+                  resource=None):
 
     def wrapper(func):
         return func

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -127,7 +127,7 @@ def _with_call_method(oncore=False, onmixin=False, onmodel=False):
             return user, param
 
         def with_resource(cls, resource, param=None):
-            return resource, param
+            return resource.id, param
 
     if onmodel:
         add_model_in_registry()
@@ -173,7 +173,7 @@ class TestCallMethod:
     def call(self, webserver, call, status=200):
         url = f'/furet-ui/resource/0/model/Model.Test/call/{call}'
         params = {'data': {'param': 1}, 'pks': {'code': 'test'}}
-        webserver.post_json(url, params, status=status)
+        return webserver.post_json(url, params, status=status)
 
     def test_undecorated_method(self, webserver, registry_call_method):
         self.call(webserver, 'not_decorated', status=403)
@@ -197,8 +197,13 @@ class TestCallMethod:
         assert response.data == ('test', 1)
 
     def test_decorated_with_resource(self, webserver, registry_call_method):
-        response = self.call(webserver, 'with_resource')
-        assert response.data == ('0', 1)
+        resource = registry_call_method.FuretUI.Resource.Custom.insert(
+            component='test')
+        call = 'with_resource'
+        url = f'/furet-ui/resource/{resource.id}/model/Model.Test/call/{call}'
+        params = {'data': {'param': 1}, 'pks': {'code': 'test'}}
+        response = webserver.post_json(url, params)
+        assert response.data == (resource.id, 1)
 
     @pytest.mark.skip()
     def test_decorated_with_permission(self, webserver, registry_call_method):

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -309,3 +309,33 @@ class TestCallMethod:
             perms=dict(do_something=dict(matched=True)))
         response = self.call(webserver, 'with_permission')
         assert response.json_body == 1
+
+    def test_menu_call_insert_with_an_exposed_method(
+        self, registry_call_method
+    ):
+        registry_call_method.FuretUI.Menu.Call.insert(
+            model='Model.Test', method='on_classmethod', label='Test')
+
+    def test_menu_call_insert_without_an_exposed_method(
+        self, registry_call_method
+    ):
+        with pytest.raises(Exception):
+            registry_call_method.FuretUI.Menu.Call.insert(
+                model='Model.Test', method='not_decorated', label='Test')
+
+    def test_menu_call_update_with_an_exposed_method(
+        self, registry_call_method
+    ):
+        menu = registry_call_method.FuretUI.Menu.Call.insert(
+            model='Model.Test', method='on_classmethod', label='Test')
+        menu.method = 'on_method'
+        registry_call_method.flush()
+
+    def test_menu_call_update_without_an_exposed_method(
+        self, registry_call_method
+    ):
+        menu = registry_call_method.FuretUI.Menu.Call.insert(
+            model='Model.Test', method='on_classmethod', label='Test')
+        with pytest.raises(Exception):
+            menu.method = 'not_decorated'
+            registry_call_method.flush()

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -89,9 +89,9 @@ def add_mixin_in_registry():
             pass
 
 
-def add_model_in_registry(MixinTest):
+def add_model_in_registry():
     @register(Model)
-    class Test(MixinTest):
+    class Test(Mixin.MixinTest):
         code = String(primary_key=True)
 
         def not_decorated(cls):
@@ -186,7 +186,7 @@ def _with_call_method(oncore=False, onmixin=False, onmodel=False):
     if onmixin:
         add_mixin_in_registry()
 
-    add_model_in_registry(MixinTest)
+    add_model_in_registry()
 
     if onmodel:
         add_model_with_decorator_in_registry()

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -1,0 +1,186 @@
+import pytest
+from anyblok import Declarations
+from anyblok.config import get_db_name
+from anyblok_furetui import furet_ui_call
+from anyblok.column import String
+from anyblok.tests.conftest import (  # noqa F401
+    init_registry_with_bloks,
+    reset_db,
+    bloks_loaded,
+    base_loaded,
+)
+
+
+register = Declarations.register
+Core = Declarations.Core
+Mixin = Declarations.Mixin
+Model = Declarations.Model
+
+
+def add_core_in_registry():
+    @register(Core)
+    class Base:
+
+        @furet_ui_call(is_classmethod=True)
+        def on_classmethod(cls, param=None):
+            pass
+
+        @furet_ui_call(is_classmethod=False)
+        def on_method(self, param=None):
+            pass
+
+        @furet_ui_call(request='request')
+        def with_request(cls, request, param=None):
+            pass
+
+        @furet_ui_call(authenticated_userid='user')
+        def with_authenticated_userid(cls, user, param=None):
+            pass
+
+
+def add_mixin_in_registry():
+
+    @register(Mixin)
+    class MixinTest:
+
+        @furet_ui_call(is_classmethod=True)
+        def on_classmethod(cls, param=None):
+            pass
+
+        @furet_ui_call(is_classmethod=False)
+        def on_method(self, param=None):
+            pass
+
+        @furet_ui_call(request='request')
+        def with_request(cls, request, param=None):
+            pass
+
+        @furet_ui_call(authenticated_userid='user')
+        def with_authenticated_userid(cls, user, param=None):
+            pass
+
+
+def add_model_in_registry():
+
+    @register(Model)
+    class Test:
+
+        @furet_ui_call(is_classmethod=True)
+        def on_classmethod(cls, param=None):
+            return super(cls, Test).on_classmethod(param=param)
+
+        @furet_ui_call(is_classmethod=False)
+        def on_method(self, param=None):
+            return super(self, Test).on_method(param=param)
+
+        @furet_ui_call(request='request')
+        def with_request(cls, request, param=None):
+            return super(cls, Test).with_request(request, param=param)
+
+        @furet_ui_call(authenticated_userid='user')
+        def with_authenticated_userid(cls, user, param=None):
+            return super(cls, Test).with_authenticated_userid(
+                user, param=param)
+
+
+def _with_call_method(oncore=False, onmixin=False, onmodel=False):
+
+    if oncore:
+        add_core_in_registry()
+
+    @register(Mixin)
+    class MixinTest:
+        pass
+
+    if onmixin:
+        add_mixin_in_registry()
+
+    @register(Model)
+    class Test(MixinTest):
+        code = String(primary_key=True)
+
+        def not_decorated(cls):
+            return True  # must be raised
+
+        def on_classmethod(cls, param=None):
+            return param
+
+        def on_method(self, param=None):
+            return self.id, param
+
+        def with_request(cls, request, param=None):
+            return request.anyblok.registry.db_name, param
+
+        def with_authenticated_userid(cls, user, param=None):
+            return user, param
+
+    if onmodel:
+        add_model_in_registry()
+
+
+KWARGS = [
+    {'oncore': True},
+    {'onmixin': True},
+    {'onmodel': True},
+    {'oncore': True, 'onmixin': True, 'onmodel': True},
+]
+
+
+@pytest.fixture(scope="class", params=KWARGS)
+def registry_call_method(request, webserver, bloks_loaded):  # noqa F811
+    reset_db()
+    registry = init_registry_with_bloks(
+        ["furetui"], _with_call_method,
+        **request.param
+    )
+    registry.Pyramid.User.insert(login='test')
+    registry.Pyramid.CredentialStore.insert(
+       login='test', password='test')
+    webserver.post_json(
+        '/furet-ui/login', {'login': 'test', 'password': 'test'},
+        status=200)
+
+    def logout():
+        webserver.post_json('/furet-ui/logout', status=200)
+        registry.close()
+
+    request.addfinalizer(logout)
+    return registry
+
+
+class TestCallMethod:
+    @pytest.fixture(autouse=True)
+    def transact(self, request, registry_call_method):
+        transaction = registry_call_method.begin_nested()
+        request.addfinalizer(transaction.rollback)
+        return
+
+    def call(self, webserver, call, status=200):
+        url = '/furet-ui/resource/0/model/Model.Test/call/%s' % call
+        params = {'data': {'param': 1}, 'pks': {'code': 'test'}}
+        webserver.post_json(url, params, status=status)
+
+    def test_undecorated_method(self, webserver, registry_call_method):
+        self.call(webserver, 'not_decorated', status=403)
+
+    def test_decorated_classmethod(self, webserver, registry_call_method):
+        response = self.call(webserver, 'on_classmethod')
+        assert response.data == 1
+
+    def test_decorated_method(self, webserver, registry_call_method):
+        registry_call_method.Test.insert(code='test')
+        response = self.call(webserver, 'on_method')
+        assert response.data == ('test', 1)
+
+    def test_decorated_with_request(self, webserver, registry_call_method):
+        response = self.call(webserver, 'with_request')
+        assert response.data == (get_db_name(), 1)
+
+    def test_decorated_with_authenticated_user(self, webserver,
+                                               registry_call_method):
+        response = self.call(webserver, 'with_authenticated_userid')
+        assert response.data == ('test', 1)
+
+    @pytest.mark.skip()
+    def test_decorated_with_permission(self, webserver, registry_call_method):
+        raise Exception('NotImplemented')

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -1,7 +1,7 @@
 import pytest
 from anyblok import Declarations
 from anyblok.config import get_db_name
-from anyblok_furetui import furet_ui_call
+from anyblok_furetui import exposed_method
 from anyblok.column import String
 from anyblok.tests.conftest import (  # noqa F401
     init_registry_with_bloks,
@@ -21,23 +21,23 @@ def add_core_in_registry():
     @register(Core)
     class Base:
 
-        @furet_ui_call(is_classmethod=True)
+        @exposed_method(is_classmethod=True)
         def on_classmethod(cls, param=None):
             pass
 
-        @furet_ui_call(is_classmethod=False)
+        @exposed_method(is_classmethod=False)
         def on_method(self, param=None):
             pass
 
-        @furet_ui_call(request='request')
+        @exposed_method(request='request')
         def with_request(cls, request, param=None):
             pass
 
-        @furet_ui_call(authenticated_userid='user')
+        @exposed_method(authenticated_userid='user')
         def with_authenticated_userid(cls, user, param=None):
             pass
 
-        @furet_ui_call(resource='resource')
+        @exposed_method(resource='resource')
         def with_resource(cls, resource, param=None):
             pass
 
@@ -47,23 +47,23 @@ def add_mixin_in_registry():
     @register(Mixin)
     class MixinTest:
 
-        @furet_ui_call(is_classmethod=True)
+        @exposed_method(is_classmethod=True)
         def on_classmethod(cls, param=None):
             pass
 
-        @furet_ui_call(is_classmethod=False)
+        @exposed_method(is_classmethod=False)
         def on_method(self, param=None):
             pass
 
-        @furet_ui_call(request='request')
+        @exposed_method(request='request')
         def with_request(cls, request, param=None):
             pass
 
-        @furet_ui_call(authenticated_userid='user')
+        @exposed_method(authenticated_userid='user')
         def with_authenticated_userid(cls, user, param=None):
             pass
 
-        @furet_ui_call(resource='resource')
+        @exposed_method(resource='resource')
         def with_resource(cls, resource, param=None):
             pass
 
@@ -73,24 +73,24 @@ def add_model_in_registry():
     @register(Model)
     class Test:
 
-        @furet_ui_call(is_classmethod=True)
+        @exposed_method(is_classmethod=True)
         def on_classmethod(cls, param=None):
             return super(cls, Test).on_classmethod(param=param)
 
-        @furet_ui_call(is_classmethod=False)
+        @exposed_method(is_classmethod=False)
         def on_method(self, param=None):
             return super(self, Test).on_method(param=param)
 
-        @furet_ui_call(request='request')
+        @exposed_method(request='request')
         def with_request(cls, request, param=None):
             return super(cls, Test).with_request(request, param=param)
 
-        @furet_ui_call(authenticated_userid='user')
+        @exposed_method(authenticated_userid='user')
         def with_authenticated_userid(cls, user, param=None):
             return super(cls, Test).with_authenticated_userid(
                 user, param=param)
 
-        @furet_ui_call(resource='resource')
+        @exposed_method(resource='resource')
         def with_resource(cls, resource, param=None):
             return super(cls, Test).with_resource(resource, param=param)
 

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -3,12 +3,7 @@ from anyblok import Declarations
 from anyblok.config import get_db_name
 from anyblok_furetui import exposed_method
 from anyblok.column import String
-from anyblok.tests.conftest import (  # noqa F401
-    init_registry_with_bloks,
-    reset_db,
-    bloks_loaded,
-    base_loaded,
-)
+from anyblok.tests.conftest import init_registry_with_bloks, reset_db
 
 
 register = Declarations.register
@@ -240,7 +235,7 @@ class TestCallMethod:
         return webserver.post_json(url, params, status=status)
 
     def test_undecorated_method(self, webserver, registry_call_method):
-        self.call(webserver, 'not_decorated', status=401)
+        self.call(webserver, 'not_decorated', status=403)
 
     def test_decorated_classmethod(self, webserver, registry_call_method):
         response = self.call(webserver, 'on_classmethod')

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -209,7 +209,7 @@ KWARGS = [
 def registry_call_method(request, webserver, bloks_loaded):  # noqa F811
     reset_db()
     registry = init_registry_with_bloks(
-        ["furetui"], _with_call_method,
+        ["furetui", "auth", "auth-password"], _with_call_method,
         **request.param
     )
     registry.Pyramid.User.insert(login='test')

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -37,6 +37,10 @@ def add_core_in_registry():
         def with_authenticated_userid(cls, user, param=None):
             pass
 
+        @furet_ui_call(resource='resource')
+        def with_resource(cls, resource, param=None):
+            pass
+
 
 def add_mixin_in_registry():
 
@@ -57,6 +61,10 @@ def add_mixin_in_registry():
 
         @furet_ui_call(authenticated_userid='user')
         def with_authenticated_userid(cls, user, param=None):
+            pass
+
+        @furet_ui_call(resource='resource')
+        def with_resource(cls, resource, param=None):
             pass
 
 
@@ -81,6 +89,10 @@ def add_model_in_registry():
         def with_authenticated_userid(cls, user, param=None):
             return super(cls, Test).with_authenticated_userid(
                 user, param=param)
+
+        @furet_ui_call(resource='resource')
+        def with_resource(cls, resource, param=None):
+            return super(cls, Test).with_resource(resource, param=param)
 
 
 def _with_call_method(oncore=False, onmixin=False, onmodel=False):
@@ -113,6 +125,9 @@ def _with_call_method(oncore=False, onmixin=False, onmodel=False):
 
         def with_authenticated_userid(cls, user, param=None):
             return user, param
+
+        def with_resource(cls, resource, param=None):
+            return resource, param
 
     if onmodel:
         add_model_in_registry()

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -29,16 +29,29 @@ def add_core_in_registry():
         def on_method(self, param=None):
             pass
 
-        @exposed_method(request='request')
-        def with_request(cls, request, param=None):
+        @exposed_method(request=True)
+        def with_request(cls, request=None, param=None):
+            pass
+
+        @exposed_method(request='request2')
+        def with_request2(cls, request2=None, param=None):
+            pass
+
+        @exposed_method(authenticated_userid=True)
+        def with_authenticated_userid(cls, authenticated_userid=None,
+                                      param=None):
             pass
 
         @exposed_method(authenticated_userid='user')
-        def with_authenticated_userid(cls, user, param=None):
+        def with_authenticated_userid2(cls, user=None, param=None):
             pass
 
-        @exposed_method(resource='resource')
-        def with_resource(cls, resource, param=None):
+        @exposed_method(resource=True)
+        def with_resource(cls, resource=None, param=None):
+            pass
+
+        @exposed_method(resource='resource2')
+        def with_resource2(cls, resource2=None, param=None):
             pass
 
 
@@ -55,58 +68,33 @@ def add_mixin_in_registry():
         def on_method(self, param=None):
             pass
 
-        @exposed_method(request='request')
-        def with_request(cls, request, param=None):
+        @exposed_method(request=True)
+        def with_request(cls, request=None, param=None):
+            pass
+
+        @exposed_method(request='request2')
+        def with_request2(cls, request2=None, param=None):
+            pass
+
+        @exposed_method(authenticated_userid=True)
+        def with_authenticated_userid(cls, authenticated_userid=None,
+                                      param=None):
             pass
 
         @exposed_method(authenticated_userid='user')
-        def with_authenticated_userid(cls, user, param=None):
+        def with_authenticated_userid2(cls, user=None, param=None):
             pass
 
-        @exposed_method(resource='resource')
-        def with_resource(cls, resource, param=None):
+        @exposed_method(resource=True)
+        def with_resource(cls, resource=None, param=None):
+            pass
+
+        @exposed_method(resource='resource2')
+        def with_resource2(cls, resource2=None, param=None):
             pass
 
 
-def add_model_in_registry():
-
-    @register(Model)
-    class Test:
-
-        @exposed_method(is_classmethod=True)
-        def on_classmethod(cls, param=None):
-            return super(Test, cls).on_classmethod(param=param)
-
-        @exposed_method(is_classmethod=False)
-        def on_method(self, param=None):
-            return super(Test, self).on_method(param=param)
-
-        @exposed_method(request='request')
-        def with_request(cls, request, param=None):
-            return super(Test, cls).with_request(request, param=param)
-
-        @exposed_method(authenticated_userid='user')
-        def with_authenticated_userid(cls, user, param=None):
-            return super(Test, cls).with_authenticated_userid(
-                user, param=param)
-
-        @exposed_method(resource='resource')
-        def with_resource(cls, resource, param=None):
-            return super(Test, cls).with_resource(resource, param=param)
-
-
-def _with_call_method(oncore=False, onmixin=False, onmodel=False):
-
-    if oncore:
-        add_core_in_registry()
-
-    @register(Mixin)
-    class MixinTest:
-        pass
-
-    if onmixin:
-        add_mixin_in_registry()
-
+def add_model_in_registry(MixinTest):
     @register(Model)
     class Test(MixinTest):
         code = String(primary_key=True)
@@ -122,19 +110,91 @@ def _with_call_method(oncore=False, onmixin=False, onmodel=False):
             return self.code, param
 
         @classmethod
-        def with_request(cls, request, param=None):
+        def with_request(cls, request=None, param=None):
             return request.anyblok.registry.db_name, param
 
         @classmethod
-        def with_authenticated_userid(cls, user, param=None):
+        def with_request2(cls, request2=None, param=None):
+            return request2.anyblok.registry.db_name, param
+
+        @classmethod
+        def with_authenticated_userid(cls, authenticated_userid=None,
+                                      param=None):
+            return authenticated_userid, param
+
+        @classmethod
+        def with_authenticated_userid2(cls, user, param=None):
             return user, param
 
         @classmethod
         def with_resource(cls, resource, param=None):
-            return resource.id, param
+            return resource.id if resource else resource, param
+
+        @classmethod
+        def with_resource2(cls, resource2, param=None):
+            return resource2.id, param
+
+
+def add_model_with_decorator_in_registry():
+    @register(Model)
+    class Test:
+
+        @exposed_method(is_classmethod=True)
+        def on_classmethod(cls, param=None):
+            return super(Test, cls).on_classmethod(param=param)
+
+        @exposed_method(is_classmethod=False)
+        def on_method(self, param=None):
+            return super(Test, self).on_method(param=param)
+
+        @exposed_method(request=True)
+        def with_request(cls, request=None, param=None):
+            return super(Test, cls).with_request(
+                request=request, param=param)
+
+        @exposed_method(request='request2')
+        def with_request2(cls, request2=None, param=None):
+            return super(Test, cls).with_request2(
+                request2=request2, param=param)
+
+        @exposed_method(authenticated_userid=True)
+        def with_authenticated_userid(cls, authenticated_userid=None,
+                                      param=None):
+            return super(Test, cls).with_authenticated_userid(
+                authenticated_userid=authenticated_userid, param=param)
+
+        @exposed_method(authenticated_userid='user')
+        def with_authenticated_userid2(cls, user=None, param=None):
+            return super(Test, cls).with_authenticated_userid2(
+                user=user, param=param)
+
+        @exposed_method(resource=True)
+        def with_resource(cls, resource=None, param=None):
+            return super(Test, cls).with_resource(
+                resource=resource, param=param)
+
+        @exposed_method(resource='resource2')
+        def with_resource2(cls, resource2=None, param=None):
+            return super(Test, cls).with_resource2(
+                resource2=resource2, param=param)
+
+
+def _with_call_method(oncore=False, onmixin=False, onmodel=False):
+
+    if oncore:
+        add_core_in_registry()
+
+    @register(Mixin)
+    class MixinTest:
+        pass
+
+    if onmixin:
+        add_mixin_in_registry()
+
+    add_model_in_registry(MixinTest)
 
     if onmodel:
-        add_model_in_registry()
+        add_model_with_decorator_in_registry()
 
 
 KWARGS = [
@@ -193,21 +253,41 @@ class TestCallMethod:
 
     def test_decorated_with_request(self, webserver, registry_call_method):
         response = self.call(webserver, 'with_request')
-        assert response.json_body == (get_db_name(), 1)
+        assert response.json_body == [get_db_name(), 1]
+
+    def test_decorated_with_request2(self, webserver, registry_call_method):
+        response = self.call(webserver, 'with_request2')
+        assert response.json_body == [get_db_name(), 1]
 
     def test_decorated_with_authenticated_user(self, webserver,
                                                registry_call_method):
         response = self.call(webserver, 'with_authenticated_userid')
-        assert response.json_body == ('test', 1)
+        assert response.json_body == ['test', 1]
 
-    def test_decorated_with_resource(self, webserver, registry_call_method):
-        resource = registry_call_method.FuretUI.Resource.Custom.insert(
-            component='test')
-        call = 'with_resource'
+    def test_decorated_with_authenticated_user2(self, webserver,
+                                                registry_call_method):
+        response = self.call(webserver, 'with_authenticated_userid2')
+        assert response.json_body == ['test', 1]
+
+    def call_with_resource(self, registry, webserver, call):
+        resource = registry.FuretUI.Resource.Custom.insert(component='test')
         url = f'/furet-ui/resource/{resource.id}/model/Model.Test/call/{call}'
         params = {'data': {'param': 1}, 'pks': {'code': 'test'}}
         response = webserver.post_json(url, params)
-        assert response.json_body == (resource.id, 1)
+        assert response.json_body == [resource.id, 1]
+
+    def test_decorated_with_resource(self, webserver, registry_call_method):
+        self.call_with_resource(
+            registry_call_method, webserver, 'with_resource')
+
+    def test_decorated_with_resource_is_0(self, webserver,
+                                          registry_call_method):
+        response = self.call(webserver, 'with_resource')
+        assert response.json_body == [None, 1]
+
+    def test_decorated_with_resource2(self, webserver, registry_call_method):
+        self.call_with_resource(
+            registry_call_method, webserver, 'with_resource2')
 
     @pytest.mark.skip()
     def test_decorated_with_permission(self, webserver, registry_call_method):

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -171,7 +171,7 @@ class TestCallMethod:
         return
 
     def call(self, webserver, call, status=200):
-        url = '/furet-ui/resource/0/model/Model.Test/call/%s' % call
+        url = f'/furet-ui/resource/0/model/Model.Test/call/{call}'
         params = {'data': {'param': 1}, 'pks': {'code': 'test'}}
         webserver.post_json(url, params, status=status)
 

--- a/anyblok_furetui/tests/test_call_method.py
+++ b/anyblok_furetui/tests/test_call_method.py
@@ -196,6 +196,10 @@ class TestCallMethod:
         response = self.call(webserver, 'with_authenticated_userid')
         assert response.data == ('test', 1)
 
+    def test_decorated_with_resource(self, webserver, registry_call_method):
+        response = self.call(webserver, 'with_resource')
+        assert response.data == ('0', 1)
+
     @pytest.mark.skip()
     def test_decorated_with_permission(self, webserver, registry_call_method):
         raise Exception('NotImplemented')

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,9 @@ setup(
             'furetui-delivery=anyblok_furetui.delivery:FuretUIDeliveryBlok',
             'furetui-filter-ip=anyblok_furetui.ip:FuretUIFilterIPBlok',
         ],
+        'anyblok.model.plugin': [
+            'exposed_method=anyblok_furetui.plugins:ExposedMethod',
+        ],
     },
     extras_require={},
 )


### PR DESCRIPTION
It is dangerous to be able to access all methods or classmethods without verification. In addition, some methods must not be accessible from the outside, otherwise it would be possible to be able to bypass the CRUD API

- [X] Authorizes the exposure of the method via a decorator
- [X] The notion of classmethod is defined in the controller (default is a classmethod)
- [X] The **request** can be passed in the method
- [X] The **authenticated_userid** can be passed in the method
- [X] The **resource** can be passed in the method
- [x] Permission key can be defined to validate if authenticated_userid is allowed to call this method
- [x] Validate that the method linked by a **Model.FuretUI.Menu.Call** is decorated

```
from anyblok_furetui import exposed_method


@register(Model)
class Test:

    @exposed_method(is_classmethod=False, request='request', authenticated_userid='user', resource='resource')
    def do_something(self, request=None, user=None, resource=None, **data_from_call):
        # do something
        return response

```